### PR TITLE
Add simple Notion-like Electron app

### DIFF
--- a/notionapp/README.md
+++ b/notionapp/README.md
@@ -1,0 +1,27 @@
+# Notion-like Electron App
+
+This example demonstrates a very lightweight Notion-style application. It uses a Go backend for storing pages and todos in memory and an Electron front‑end so the app can be used locally on Linux systems such as Arch.
+
+## Building the Go server
+
+Ensure Go (1.21 or newer) is installed then run:
+
+```bash
+go run main.go
+```
+
+The API listens on `http://localhost:8081`.
+
+## Running the Electron front‑end
+
+Inside the `frontend` directory install the node dependencies and start Electron:
+
+```bash
+cd frontend
+npm install
+npm run start
+```
+
+This opens the desktop application window. Pages are stored in memory only, so data is lost when the server stops.
+
+This is just a minimal proof of concept implementing pages, markdown notes and simple todo lists along with sub‑pages. It can be extended to support additional features such as tables, calendars and persistent storage.

--- a/notionapp/frontend/app.js
+++ b/notionapp/frontend/app.js
@@ -1,0 +1,103 @@
+let currentPage = null;
+
+async function fetchPages() {
+  const res = await fetch('http://localhost:8081/api/pages');
+  const pages = await res.json();
+  const list = document.getElementById('pageList');
+  list.innerHTML = '';
+  pages.forEach(p => {
+    const li = document.createElement('li');
+    const a = document.createElement('a');
+    a.href = '#';
+    a.textContent = p.title;
+    a.onclick = () => loadPage(p.id);
+    li.appendChild(a);
+    list.appendChild(li);
+  });
+}
+
+async function createPage() {
+  const title = document.getElementById('newPageTitle').value;
+  const res = await fetch('http://localhost:8081/api/pages', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ title })
+  });
+  await res.json();
+  document.getElementById('newPageTitle').value = '';
+  fetchPages();
+}
+
+async function loadPage(id) {
+  const res = await fetch(`http://localhost:8081/api/pages/${id}`);
+  const page = await res.json();
+  currentPage = page.id;
+  document.getElementById('pageTitle').textContent = page.title;
+  document.getElementById('markdown').value = page.content || '';
+  renderTodos(page.todos);
+  renderSubPages(page.children);
+}
+
+function renderTodos(todos) {
+  const list = document.getElementById('todoList');
+  list.innerHTML = '';
+  todos.forEach(t => {
+    const li = document.createElement('li');
+    const cb = document.createElement('input');
+    cb.type = 'checkbox';
+    cb.checked = t.done;
+    cb.onchange = () => updateTodo(t.id, cb.checked);
+    li.appendChild(cb);
+    li.appendChild(document.createTextNode(' '+t.text));
+    list.appendChild(li);
+  });
+}
+
+async function addTodo() {
+  const text = document.getElementById('newTodoText').value;
+  await fetch(`http://localhost:8081/api/pages/${currentPage}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ text })
+  });
+  document.getElementById('newTodoText').value = '';
+  loadPage(currentPage);
+}
+
+async function updateTodo(id, done) {
+  await fetch(`http://localhost:8081/api/pages/${currentPage}/todos/${id}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ done })
+  });
+}
+
+function renderSubPages(ids) {
+  const list = document.getElementById('subPageList');
+  list.innerHTML = '';
+  ids.forEach(async id => {
+    const res = await fetch(`http://localhost:8081/api/pages/${id}`);
+    const page = await res.json();
+    const li = document.createElement('li');
+    const a = document.createElement('a');
+    a.href = '#';
+    a.textContent = page.title;
+    a.onclick = () => loadPage(page.id);
+    li.appendChild(a);
+    list.appendChild(li);
+  });
+}
+
+async function createSubPage() {
+  const title = document.getElementById('newSubPageTitle').value;
+  await fetch('http://localhost:8081/api/pages', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ title, parent_id: currentPage })
+  });
+  document.getElementById('newSubPageTitle').value = '';
+  loadPage(currentPage);
+  fetchPages();
+}
+
+fetchPages();

--- a/notionapp/frontend/index.html
+++ b/notionapp/frontend/index.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>Notion-like App</title>
+<link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <div id="sidebar">
+    <h2>Pages</h2>
+    <ul id="pageList"></ul>
+    <input id="newPageTitle" placeholder="New Page"/>
+    <button onclick="createPage()">Create</button>
+  </div>
+  <div id="content">
+    <h2 id="pageTitle"></h2>
+    <textarea id="markdown" placeholder="Write in markdown"></textarea>
+    <h3>Todos</h3>
+    <ul id="todoList"></ul>
+    <input id="newTodoText" placeholder="New todo"/>
+    <button onclick="addTodo()">Add Todo</button>
+    <h3>Subpages</h3>
+    <ul id="subPageList"></ul>
+    <input id="newSubPageTitle" placeholder="New subpage"/>
+    <button onclick="createSubPage()">Create Subpage</button>
+  </div>
+<script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+<script src="app.js"></script>
+</body>
+</html>

--- a/notionapp/frontend/main.js
+++ b/notionapp/frontend/main.js
@@ -1,0 +1,26 @@
+const { app, BrowserWindow } = require('electron');
+const path = require('path');
+
+function createWindow () {
+  const win = new BrowserWindow({
+    width: 1000,
+    height: 800,
+    webPreferences: {
+      preload: path.join(__dirname, 'renderer.js')
+    }
+  });
+
+  win.loadFile('index.html');
+}
+
+app.whenReady().then(() => {
+  createWindow();
+
+  app.on('activate', function () {
+    if (BrowserWindow.getAllWindows().length === 0) createWindow();
+  });
+});
+
+app.on('window-all-closed', function () {
+  if (process.platform !== 'darwin') app.quit();
+});

--- a/notionapp/frontend/package.json
+++ b/notionapp/frontend/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "notionapp",
+  "version": "1.0.0",
+  "main": "main.js",
+  "scripts": {
+    "start": "electron ."
+  },
+  "devDependencies": {
+    "electron": "26.2.4"
+  }
+}

--- a/notionapp/frontend/renderer.js
+++ b/notionapp/frontend/renderer.js
@@ -1,0 +1,3 @@
+const { contextBridge } = require('electron');
+const fs = require('fs');
+// Preload script not needed for this simple app

--- a/notionapp/frontend/styles.css
+++ b/notionapp/frontend/styles.css
@@ -1,0 +1,5 @@
+body { display: flex; font-family: sans-serif; margin: 0; }
+#sidebar { width: 200px; background: #f5f5f5; padding: 10px; height: 100vh; overflow-y: auto; }
+#content { flex: 1; padding: 10px; }
+ul { list-style: none; padding: 0; }
+textarea { width: 100%; height: 200px; }

--- a/notionapp/go.mod
+++ b/notionapp/go.mod
@@ -1,0 +1,3 @@
+module notionapp
+
+go 1.24.3

--- a/notionapp/main.go
+++ b/notionapp/main.go
@@ -1,0 +1,169 @@
+package main
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+// Todo represents a todo item
+type Todo struct {
+	ID   int    `json:"id"`
+	Text string `json:"text"`
+	Done bool   `json:"done"`
+}
+
+// Page represents a page with markdown content and todos
+type Page struct {
+	ID       int    `json:"id"`
+	Title    string `json:"title"`
+	Content  string `json:"content"`
+	ParentID *int   `json:"parent_id,omitempty"`
+	Todos    []Todo `json:"todos"`
+	Children []int  `json:"children"`
+}
+
+var (
+	pages   = make(map[int]*Page)
+	pagesMu sync.Mutex
+	nextID  int
+	todoID  int
+)
+
+func main() {
+	http.HandleFunc("/api/pages", pagesHandler)
+	http.HandleFunc("/api/pages/", pageHandler)
+	http.HandleFunc("/", serveIndex)
+
+	log.Println("Starting server on :8081")
+	log.Fatal(http.ListenAndServe(":8081", nil))
+}
+
+func serveIndex(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/" {
+		http.NotFound(w, r)
+		return
+	}
+	http.ServeFile(w, r, "frontend/index.html")
+}
+
+// pagesHandler handles listing and creating top-level pages
+func pagesHandler(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		pagesMu.Lock()
+		defer pagesMu.Unlock()
+		list := []Page{}
+		for _, p := range pages {
+			if p.ParentID == nil {
+				list = append(list, *p)
+			}
+		}
+		json.NewEncoder(w).Encode(list)
+	case http.MethodPost:
+		var p Page
+		if err := json.NewDecoder(r.Body).Decode(&p); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		pagesMu.Lock()
+		p.ID = nextID
+		nextID++
+		pages[p.ID] = &p
+		if p.ParentID != nil {
+			if parent, ok := pages[*p.ParentID]; ok {
+				parent.Children = append(parent.Children, p.ID)
+			}
+		}
+		pagesMu.Unlock()
+		json.NewEncoder(w).Encode(p)
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+// pageHandler handles fetching a page and manipulating todos
+func pageHandler(w http.ResponseWriter, r *http.Request) {
+	rest := r.URL.Path[len("/api/pages/"):]
+	if rest == "" {
+		http.NotFound(w, r)
+		return
+	}
+	parts := strings.Split(rest, "/")
+	idStr := parts[0]
+	pagesMu.Lock()
+	p, ok := pages[toInt(idStr)]
+	pagesMu.Unlock()
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+
+	// handle todo update
+	if len(parts) == 3 && parts[1] == "todos" {
+		todoIDStr := parts[2]
+		if r.Method != http.MethodPut {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		pagesMu.Lock()
+		for i := range p.Todos {
+			if p.Todos[i].ID == toInt(todoIDStr) {
+				var body struct {
+					Done bool `json:"done"`
+				}
+				if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+					pagesMu.Unlock()
+					http.Error(w, err.Error(), http.StatusBadRequest)
+					return
+				}
+				p.Todos[i].Done = body.Done
+				json.NewEncoder(w).Encode(p.Todos[i])
+				pagesMu.Unlock()
+				return
+			}
+		}
+		pagesMu.Unlock()
+		http.NotFound(w, r)
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		json.NewEncoder(w).Encode(p)
+	case http.MethodPut:
+		var updated Page
+		if err := json.NewDecoder(r.Body).Decode(&updated); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		pagesMu.Lock()
+		p.Title = updated.Title
+		p.Content = updated.Content
+		pagesMu.Unlock()
+		json.NewEncoder(w).Encode(p)
+	case http.MethodPost:
+		// create todo
+		var t Todo
+		if err := json.NewDecoder(r.Body).Decode(&t); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		pagesMu.Lock()
+		t.ID = todoID
+		todoID++
+		p.Todos = append(p.Todos, t)
+		pagesMu.Unlock()
+		json.NewEncoder(w).Encode(t)
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func toInt(s string) int {
+	i, _ := strconv.Atoi(s)
+	return i
+}


### PR DESCRIPTION
## Summary
- add `notionapp` example using Go for the backend
- implement Electron based frontend with pages, todos and subpages
- include basic styling and instructions

## Testing
- `go vet ./...`
- `npm install` *(fails: network disabled)*

------
https://chatgpt.com/codex/tasks/task_e_6884b2ccebd8832f9efbf0dfa651855c